### PR TITLE
Passing to Simple Logging Facade for java - slf4j 

### DIFF
--- a/DiabeteHelperBE/pom.xml
+++ b/DiabeteHelperBE/pom.xml
@@ -29,6 +29,14 @@
       <scope>provided</scope>
     </dependency>
 
+    <!-- Logging - See this guide: https://www.marcobehler.com/guides/a-guide-to-logging-in-java#_modern_logging_libraries -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.25</version>
+    </dependency>
+
+
     <!-- Auto Mapper -->
     <dependency>
       <groupId>net.sf.dozer</groupId>

--- a/DiabeteHelperBE/src/main/java/com/pyrosandro/config/DiabeteProducers.java
+++ b/DiabeteHelperBE/src/main/java/com/pyrosandro/config/DiabeteProducers.java
@@ -1,8 +1,10 @@
 package com.pyrosandro.config;
 
 
-import org.apache.log4j.Logger;
+
 import org.dozer.DozerBeanMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.enterprise.inject.Produces;
 import javax.enterprise.inject.spi.InjectionPoint;
@@ -21,7 +23,7 @@ public class DiabeteProducers {
 
     @Produces
     public Logger produceLogger(InjectionPoint injectionPoint) {
-        return Logger.getLogger(injectionPoint.getMember().getDeclaringClass().getName());
+        return LoggerFactory.getLogger(injectionPoint.getMember().getDeclaringClass().getName());
     }
 
     //Auto mapper

--- a/DiabeteHelperBE/src/main/java/com/pyrosandro/resources/AlimentResource.java
+++ b/DiabeteHelperBE/src/main/java/com/pyrosandro/resources/AlimentResource.java
@@ -6,7 +6,8 @@ import com.pyrosandro.DTO.CalculatorDTO;
 import com.pyrosandro.entities.Aliment;
 import com.pyrosandro.services.AlimentService;
 import com.pyrosandro.utils.DiabeteMapper;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+
 
 import javax.inject.Inject;
 import javax.ws.rs.*;


### PR DESCRIPTION
**Guide Link:** https://www.marcobehler.com/guides/a-guide-to-logging-in-java

To get started with SLF4J, you only need one library on the classpath, the slf4j-api dependency
<dependency>
    <groupId>org.slf4j</groupId>
    <artifactId>slf4j-api</artifactId>
    <version>1.7.25</version>
</dependency>

IMPORTANT: **SLF4J cannot do logging itself. It needs a logging library to do the actual logging**, like Log4j, JUL, Logback etc.
So, say you want to use Log4j v1, you would then need the slf4j-log4j12 binding library in your classpath:
<dependency>
    <groupId>org.slf4j</groupId>
    <artifactId>slf4j-log4j12</artifactId>
    <version>1.7.25</version>
</dependency>

Why do I use this library then for logging?

The beauty of this approach is, that **your code only knows SLF4J**. There are no references to Log4j, Logback or Jul. And if you are writing a library, that’s even better. Because if your library uses SLF4J, then the end-user of your library can decide to log either with Log4j, or Logback, or whatever library he wants. Because that choice can simply be made by adding or removing a couple of jars to or from the classpath.

